### PR TITLE
remove unnecessary code

### DIFF
--- a/get_cut_cmd.py
+++ b/get_cut_cmd.py
@@ -47,7 +47,6 @@ while video.isOpened():
         was_bkout = False
 
 video.release()
-cv2.destroyAllWindows()
 
 bkout_frames = np.array(bkout_frames)
 bkout_sec = np.where(bkout_frames==1)[0] / fps


### PR DESCRIPTION
remove `cv2.destroyAllWindows()`.

probably not necessary because this scritp not using window method like cv2.imshow.

